### PR TITLE
Tests for db functions

### DIFF
--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -3,5 +3,6 @@ package storage
 import "errors"
 
 var (
-	RecordNotFound = errors.New("record not found")
+	ErrorRecordNotFound  = errors.New("record not found")
+	ErrorNoRecordUpdated = errors.New("no record updated")
 )

--- a/internal/storage/sqlite/connection.go
+++ b/internal/storage/sqlite/connection.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"embed"
 	"fmt"
+
 	_ "modernc.org/sqlite"
 )
 
@@ -50,8 +51,6 @@ func (it *Connection) All(sqlString string, params ...any) (*sql.Rows, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	defer rows.Close()
 
 	return rows, nil
 }

--- a/internal/storage/sqlite/file_store.go
+++ b/internal/storage/sqlite/file_store.go
@@ -24,12 +24,16 @@ func (fs *FileStore) ForId(id core.FileId, deleted bool) (*core.File, error) {
 	}
 
 	var f core.File
+	var gid sql.NullString
 
-	if err = row.Scan(&f.FileId, &f.GroupId, &f.SyncVersion, &f.EncryptMeta, &f.EncryptKeyId, &f.EncryptSalt, &f.EncryptTest, &f.Deleted, &f.Name); err != nil {
+	if err = row.Scan(&f.FileId, &gid, &f.SyncVersion, &f.EncryptMeta, &f.EncryptKeyId, &f.EncryptSalt, &f.EncryptTest, &f.Deleted, &f.Name); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, storage.ErrorRecordNotFound
 		}
 		return nil, err
+	}
+	if gid.Valid {
+		f.GroupId = gid.String
 	}
 
 	return &f, nil
@@ -45,9 +49,15 @@ func (fs *FileStore) All() ([]*core.File, error) {
 	files := make([]*core.File, 0)
 	for rows.Next() {
 		var f core.File
-		if err := rows.Scan(&f.FileId, &f.GroupId, &f.SyncVersion, &f.EncryptMeta, &f.EncryptKeyId, &f.EncryptSalt, &f.EncryptTest, &f.Deleted, &f.Name); err != nil {
+		var gid sql.NullString
+
+		if err := rows.Scan(&f.FileId, &gid, &f.SyncVersion, &f.EncryptMeta, &f.EncryptKeyId, &f.EncryptSalt, &f.EncryptTest, &f.Deleted, &f.Name); err != nil {
 			return nil, err
 		}
+		if gid.Valid {
+			f.GroupId = gid.String
+		}
+
 		files = append(files, &f)
 	}
 

--- a/internal/storage/sqlite/file_store.go
+++ b/internal/storage/sqlite/file_store.go
@@ -1,7 +1,10 @@
 package sqlite
 
 import (
+	"database/sql"
+
 	"github.com/nathanjisaac/actual-server-go/internal/core"
+	"github.com/nathanjisaac/actual-server-go/internal/storage"
 )
 
 type FileStore struct {
@@ -23,6 +26,9 @@ func (fs *FileStore) ForId(id core.FileId, deleted bool) (*core.File, error) {
 	var f core.File
 
 	if err = row.Scan(&f.FileId, &f.GroupId, &f.SyncVersion, &f.EncryptMeta, &f.EncryptKeyId, &f.EncryptSalt, &f.EncryptTest, &f.Deleted, &f.Name); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, storage.ErrorRecordNotFound
+		}
 		return nil, err
 	}
 
@@ -34,6 +40,7 @@ func (fs *FileStore) All() ([]*core.File, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	files := make([]*core.File, 0)
 	for rows.Next() {
@@ -48,9 +55,11 @@ func (fs *FileStore) All() ([]*core.File, error) {
 }
 
 func (fs *FileStore) Update(file *core.File) error {
-	_, _, err := fs.connection.Mutate("UPDATE files SET sync_version = ?, encrypt_meta = ? WHERE id = ?", file.SyncVersion, file.EncryptMeta, file.FileId)
+	rows, _, err := fs.connection.Mutate("UPDATE files SET sync_version = ?, encrypt_meta = ? WHERE id = ?", file.SyncVersion, file.EncryptMeta, file.FileId)
 	if err != nil {
 		return err
+	} else if rows == 0 {
+		return storage.ErrorNoRecordUpdated
 	}
 
 	return nil
@@ -66,45 +75,55 @@ func (fs *FileStore) Add(file *core.NewFile) error {
 }
 
 func (fs *FileStore) ClearGroup(id core.FileId) error {
-	_, _, err := fs.connection.Mutate("UPDATE files SET group_id = NULL WHERE id = ?", id)
+	rows, _, err := fs.connection.Mutate("UPDATE files SET group_id = NULL WHERE id = ?", id)
 	if err != nil {
 		return err
+	} else if rows == 0 {
+		return storage.ErrorNoRecordUpdated
 	}
 
 	return nil
 }
 
 func (fs *FileStore) Delete(id core.FileId) error {
-	_, _, err := fs.connection.Mutate("UPDATE files SET deleted = TRUE WHERE id = ?", id)
+	rows, _, err := fs.connection.Mutate("UPDATE files SET deleted = TRUE WHERE id = ?", id)
 	if err != nil {
 		return err
+	} else if rows == 0 {
+		return storage.ErrorNoRecordUpdated
 	}
 
 	return nil
 }
 
 func (fs *FileStore) UpdateName(id core.FileId, name string) error {
-	_, _, err := fs.connection.Mutate("UPDATE files SET name = ? WHERE id = ?", name, id)
+	rows, _, err := fs.connection.Mutate("UPDATE files SET name = ? WHERE id = ?", name, id)
 	if err != nil {
 		return err
+	} else if rows == 0 {
+		return storage.ErrorNoRecordUpdated
 	}
 
 	return nil
 }
 
 func (fs *FileStore) UpdateGroup(id core.FileId, groupId string) error {
-	_, _, err := fs.connection.Mutate("UPDATE files SET group_id = ? WHERE id = ?", groupId, id)
+	rows, _, err := fs.connection.Mutate("UPDATE files SET group_id = ? WHERE id = ?", groupId, id)
 	if err != nil {
 		return err
+	} else if rows == 0 {
+		return storage.ErrorNoRecordUpdated
 	}
 
 	return nil
 }
 
 func (fs *FileStore) UpdateEncryption(id core.FileId, salt, keyId, test string) error {
-	_, _, err := fs.connection.Mutate("UPDATE files SET encrypt_salt = ?, encrypt_keyid = ?, encrypt_test = ? WHERE id = ?", salt, keyId, test, id)
+	rows, _, err := fs.connection.Mutate("UPDATE files SET encrypt_salt = ?, encrypt_keyid = ?, encrypt_test = ? WHERE id = ?", salt, keyId, test, id)
 	if err != nil {
 		return err
+	} else if rows == 0 {
+		return storage.ErrorNoRecordUpdated
 	}
 
 	return nil

--- a/internal/storage/sqlite/file_store_test.go
+++ b/internal/storage/sqlite/file_store_test.go
@@ -1,0 +1,285 @@
+package sqlite_test
+
+import (
+	"testing"
+
+	"github.com/nathanjisaac/actual-server-go/internal/core"
+	"github.com/nathanjisaac/actual-server-go/internal/storage"
+	"github.com/nathanjisaac/actual-server-go/internal/storage/sqlite"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestFileStore(t *testing.T) (*sqlite.FileStore, *sqlite.Connection) {
+	conn, err := sqlite.NewConnection(":memory:")
+	assert.NoError(t, err)
+
+	return sqlite.NewFileStore(conn), conn
+}
+
+func TestFileStore_ForId(t *testing.T) {
+	t.Run("given no rows", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		_, err := store.ForId("1", false)
+
+		assert.ErrorIs(t, err, storage.ErrorRecordNotFound)
+	})
+
+	t.Run("given three rows returns second", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		err := store.Add(&core.NewFile{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", Name: "Budget"})
+		assert.NoError(t, err)
+		err = store.UpdateEncryption("1", "salt1", "keyid1", "test1")
+		assert.NoError(t, err)
+
+		err = store.Add(&core.NewFile{FileId: "2", GroupId: "g2", SyncVersion: 2, EncryptMeta: "B1F2G3", Name: "Budget2"})
+		assert.NoError(t, err)
+		err = store.UpdateEncryption("2", "salt2", "keyid2", "test2")
+		assert.NoError(t, err)
+
+		err = store.Add(&core.NewFile{FileId: "3", GroupId: "g3", SyncVersion: 3, EncryptMeta: "B4F7G9", Name: "Budget3"})
+		assert.NoError(t, err)
+		err = store.UpdateEncryption("3", "salt3", "keyid3", "test3")
+		assert.NoError(t, err)
+
+		f, err := store.ForId("2", false)
+
+		assert.NoError(t, err)
+		assert.Equal(t, &core.File{FileId: "2", GroupId: "g2", SyncVersion: 2, EncryptMeta: "B1F2G3", EncryptSalt: "salt2", EncryptKeyId: "keyid2", EncryptTest: "test2", Deleted: false, Name: "Budget2"}, f)
+	})
+}
+
+func TestFileStore_All(t *testing.T) {
+	t.Run("given no rows", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		files, err := store.All()
+
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(files))
+	})
+
+	t.Run("given three rows returns all", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		err := store.Add(&core.NewFile{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", Name: "Budget1"})
+		assert.NoError(t, err)
+		err = store.UpdateEncryption("1", "salt1", "keyid1", "test1")
+		assert.NoError(t, err)
+
+		err = store.Add(&core.NewFile{FileId: "2", GroupId: "g2", SyncVersion: 2, EncryptMeta: "B1F2G3", Name: "Budget2"})
+		assert.NoError(t, err)
+		err = store.UpdateEncryption("2", "salt2", "keyid2", "test2")
+		assert.NoError(t, err)
+
+		err = store.Add(&core.NewFile{FileId: "3", GroupId: "g3", SyncVersion: 3, EncryptMeta: "B4F7G9", Name: "Budget3"})
+		assert.NoError(t, err)
+		err = store.UpdateEncryption("3", "salt3", "keyid3", "test3")
+		assert.NoError(t, err)
+
+		files, err := store.All()
+
+		assert.NoError(t, err)
+		assert.Equal(t, 3, len(files))
+		assert.Equal(t, &core.File{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: false, Name: "Budget1"}, files[0])
+		assert.Equal(t, &core.File{FileId: "2", GroupId: "g2", SyncVersion: 2, EncryptMeta: "B1F2G3", EncryptSalt: "salt2", EncryptKeyId: "keyid2", EncryptTest: "test2", Deleted: false, Name: "Budget2"}, files[1])
+		assert.Equal(t, &core.File{FileId: "3", GroupId: "g3", SyncVersion: 3, EncryptMeta: "B4F7G9", EncryptSalt: "salt3", EncryptKeyId: "keyid3", EncryptTest: "test3", Deleted: false, Name: "Budget3"}, files[2])
+	})
+}
+
+func TestFileStore_Update(t *testing.T) {
+	t.Run("given no row with matching id", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		err := store.Update(&core.File{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: false, Name: "Budget1"})
+
+		assert.ErrorIs(t, err, storage.ErrorNoRecordUpdated)
+	})
+
+	t.Run("given row with matching id", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		err := store.Add(&core.NewFile{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", Name: "Budget1"})
+		assert.NoError(t, err)
+		err = store.UpdateEncryption("1", "salt1", "keyid1", "test1")
+		assert.NoError(t, err)
+
+		err = store.Update(&core.File{FileId: "1", GroupId: "g1", SyncVersion: 2, EncryptMeta: "X9Y6Z7", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: false, Name: "Budget1"})
+		assert.NoError(t, err)
+
+		f, err := store.ForId("1", false)
+
+		assert.NoError(t, err)
+		assert.Equal(t, &core.File{FileId: "1", GroupId: "g1", SyncVersion: 2, EncryptMeta: "X9Y6Z7", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: false, Name: "Budget1"}, f)
+	})
+}
+
+func TestFileStore_Add(t *testing.T) {
+	t.Run("add new row", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		err := store.Add(&core.NewFile{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", Name: "Budget1"})
+		assert.NoError(t, err)
+		err = store.UpdateEncryption("1", "salt1", "keyid1", "test1")
+		assert.NoError(t, err)
+
+		f, err := store.ForId("1", false)
+
+		assert.NoError(t, err)
+		assert.Equal(t, &core.File{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: false, Name: "Budget1"}, f)
+	})
+}
+
+func TestFileStore_ClearGroup(t *testing.T) {
+	t.Run("given no row with matching id", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		err := store.ClearGroup("1")
+
+		assert.ErrorIs(t, err, storage.ErrorNoRecordUpdated)
+	})
+
+	t.Run("given row with matching id", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		err := store.Add(&core.NewFile{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", Name: "Budget1"})
+		assert.NoError(t, err)
+		err = store.UpdateEncryption("1", "salt1", "keyid1", "test1")
+		assert.NoError(t, err)
+
+		err = store.ClearGroup("1")
+		assert.NoError(t, err)
+
+		// TODO: The snuppet below can be used when File.GroupId type is made NULLABLE
+		// f, err := store.ForId("1", false)
+
+		// assert.NoError(t, err)
+		// assert.Equal(t, &core.File{FileId: "1", GroupId: nil, SyncVersion: 1, EncryptMeta: "A1B2C3", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: false, Name: "Budget1"}, f)
+	})
+}
+
+func TestFileStore_Delete(t *testing.T) {
+	t.Run("given no row with matching id", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		err := store.Delete("1")
+
+		assert.ErrorIs(t, err, storage.ErrorNoRecordUpdated)
+	})
+
+	t.Run("given row with matching id", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		err := store.Add(&core.NewFile{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", Name: "Budget1"})
+		assert.NoError(t, err)
+		err = store.UpdateEncryption("1", "salt1", "keyid1", "test1")
+		assert.NoError(t, err)
+
+		err = store.Delete("1")
+		assert.NoError(t, err)
+
+		f, err := store.ForId("1", true)
+
+		assert.NoError(t, err)
+		assert.Equal(t, &core.File{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: true, Name: "Budget1"}, f)
+	})
+}
+
+func TestFileStore_UpdateName(t *testing.T) {
+	t.Run("given no row with matching id", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		err := store.UpdateName("1", "My budget")
+
+		assert.ErrorIs(t, err, storage.ErrorNoRecordUpdated)
+	})
+
+	t.Run("given row with matching id", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		err := store.Add(&core.NewFile{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", Name: "Budget1"})
+		assert.NoError(t, err)
+		err = store.UpdateEncryption("1", "salt1", "keyid1", "test1")
+		assert.NoError(t, err)
+
+		err = store.UpdateName("1", "My budget")
+		assert.NoError(t, err)
+
+		f, err := store.ForId("1", false)
+
+		assert.NoError(t, err)
+		assert.Equal(t, &core.File{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: false, Name: "My budget"}, f)
+	})
+}
+
+func TestFileStore_UpdateGroup(t *testing.T) {
+	t.Run("given no row with matching id", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		err := store.UpdateGroup("1", "gnew")
+
+		assert.ErrorIs(t, err, storage.ErrorNoRecordUpdated)
+	})
+
+	t.Run("given row with matching id", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		err := store.Add(&core.NewFile{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", Name: "Budget1"})
+		assert.NoError(t, err)
+		err = store.UpdateEncryption("1", "salt1", "keyid1", "test1")
+		assert.NoError(t, err)
+
+		err = store.UpdateGroup("1", "gnew")
+		assert.NoError(t, err)
+
+		f, err := store.ForId("1", false)
+
+		assert.NoError(t, err)
+		assert.Equal(t, &core.File{FileId: "1", GroupId: "gnew", SyncVersion: 1, EncryptMeta: "A1B2C3", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: false, Name: "Budget1"}, f)
+	})
+}
+
+func TestFileStore_UpdateEncryption(t *testing.T) {
+	t.Run("given no row with matching id", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		err := store.UpdateEncryption("1", "saltNew", "keyidNew", "testNew")
+
+		assert.ErrorIs(t, err, storage.ErrorNoRecordUpdated)
+	})
+
+	t.Run("given row with matching id", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		err := store.Add(&core.NewFile{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", Name: "Budget1"})
+		assert.NoError(t, err)
+		err = store.UpdateEncryption("1", "salt1", "keyid1", "test1")
+		assert.NoError(t, err)
+
+		err = store.UpdateEncryption("1", "saltNew", "keyidNew", "testNew")
+		assert.NoError(t, err)
+
+		f, err := store.ForId("1", false)
+
+		assert.NoError(t, err)
+		assert.Equal(t, &core.File{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", EncryptSalt: "saltNew", EncryptKeyId: "keyidNew", EncryptTest: "testNew", Deleted: false, Name: "Budget1"}, f)
+	})
+}

--- a/internal/storage/sqlite/file_store_test.go
+++ b/internal/storage/sqlite/file_store_test.go
@@ -160,11 +160,10 @@ func TestFileStore_ClearGroup(t *testing.T) {
 		err = store.ClearGroup("1")
 		assert.NoError(t, err)
 
-		// TODO: The snuppet below can be used when File.GroupId type is made NULLABLE
-		// f, err := store.ForId("1", false)
+		f, err := store.ForId("1", false)
 
-		// assert.NoError(t, err)
-		// assert.Equal(t, &core.File{FileId: "1", GroupId: nil, SyncVersion: 1, EncryptMeta: "A1B2C3", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: false, Name: "Budget1"}, f)
+		assert.NoError(t, err)
+		assert.Equal(t, &core.File{FileId: "1", GroupId: "", SyncVersion: 1, EncryptMeta: "A1B2C3", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: false, Name: "Budget1"}, f)
 	})
 }
 

--- a/internal/storage/sqlite/password_store_test.go
+++ b/internal/storage/sqlite/password_store_test.go
@@ -1,0 +1,128 @@
+package sqlite_test
+
+import (
+	"testing"
+
+	"github.com/nathanjisaac/actual-server-go/internal/storage"
+	"github.com/nathanjisaac/actual-server-go/internal/storage/sqlite"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestPasswordStore(t *testing.T) (*sqlite.PasswordStore, *sqlite.Connection) {
+	conn, err := sqlite.NewConnection(":memory:")
+	assert.NoError(t, err)
+
+	return sqlite.NewPasswordStore(conn), conn
+}
+
+func TestPasswordStore_Count(t *testing.T) {
+	t.Run("given no rows", func(t *testing.T) {
+		store, conn := newTestPasswordStore(t)
+		defer conn.Close()
+
+		c, err := store.Count()
+
+		assert.NoError(t, err)
+		assert.Equal(t, 0, c)
+	})
+
+	t.Run("given two row", func(t *testing.T) {
+		store, conn := newTestPasswordStore(t)
+		defer conn.Close()
+
+		err := store.Add("password0")
+		assert.NoError(t, err)
+		err = store.Add("password1")
+		assert.NoError(t, err)
+
+		c, err := store.Count()
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, c)
+	})
+}
+
+func TestPasswordStore_First(t *testing.T) {
+	t.Run("given no rows", func(t *testing.T) {
+		store, conn := newTestPasswordStore(t)
+		defer conn.Close()
+
+		_, err := store.First()
+
+		assert.ErrorIs(t, err, storage.ErrorRecordNotFound)
+	})
+
+	t.Run("given one row", func(t *testing.T) {
+		store, conn := newTestPasswordStore(t)
+		defer conn.Close()
+
+		err := store.Add("password")
+		assert.NoError(t, err)
+
+		password, err := store.First()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "password", password)
+	})
+
+	t.Run("given two rows then return first", func(t *testing.T) {
+		store, conn := newTestPasswordStore(t)
+		defer conn.Close()
+
+		err := store.Add("a")
+		assert.NoError(t, err)
+		err = store.Add("b")
+		assert.NoError(t, err)
+
+		password, err := store.First()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "a", password)
+	})
+}
+
+func TestPasswordStore_Add(t *testing.T) {
+	t.Run("add new row", func(t *testing.T) {
+		store, conn := newTestPasswordStore(t)
+		defer conn.Close()
+
+		err := store.Add("password")
+		assert.NoError(t, err)
+
+		p, err := store.First()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "password", p)
+	})
+}
+
+func TestPasswordStore_Set(t *testing.T) {
+	t.Run("given no row", func(t *testing.T) {
+		store, conn := newTestPasswordStore(t)
+		defer conn.Close()
+
+		err := store.Set("password")
+		assert.ErrorIs(t, err, storage.ErrorNoRecordUpdated)
+	})
+
+	t.Run("given one row", func(t *testing.T) {
+		store, conn := newTestPasswordStore(t)
+		defer conn.Close()
+
+		err := store.Add("password")
+		assert.NoError(t, err)
+
+		p, err := store.First()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "password", p)
+
+		err = store.Set("newPassword")
+		assert.NoError(t, err)
+
+		p, err = store.First()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "newPassword", p)
+	})
+}

--- a/internal/storage/sqlite/token_store.go
+++ b/internal/storage/sqlite/token_store.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"database/sql"
+
 	"github.com/nathanjisaac/actual-server-go/internal/core"
 	"github.com/nathanjisaac/actual-server-go/internal/storage"
 )
@@ -17,22 +18,22 @@ func NewTokenStore(connection *Connection) *TokenStore {
 }
 
 func (a *TokenStore) First() (core.Token, error) {
-	var password core.Token
+	var token core.Token
 
 	row, err := a.connection.First("SELECT * FROM sessions")
 
 	if err != nil {
-		return password, err
+		return token, err
 	}
 
-	if err = row.Scan(&password); err != nil {
+	if err = row.Scan(&token); err != nil {
 		if err == sql.ErrNoRows {
-			return password, storage.RecordNotFound
+			return token, storage.ErrorRecordNotFound
 		}
-		return password, err
+		return token, err
 	}
 
-	return password, nil
+	return token, nil
 }
 
 func (a *TokenStore) Add(token core.Token) error {

--- a/internal/storage/sqlite/token_store_test.go
+++ b/internal/storage/sqlite/token_store_test.go
@@ -1,29 +1,33 @@
-package sqlite
+package sqlite_test
 
 import (
-	"github.com/nathanjisaac/actual-server-go/internal/storage"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/nathanjisaac/actual-server-go/internal/storage"
+	"github.com/nathanjisaac/actual-server-go/internal/storage/sqlite"
+	"github.com/stretchr/testify/assert"
 )
 
-func newStore(t *testing.T) *TokenStore {
-	conn, err := NewConnection(":memory:")
+func newTestTokenStore(t *testing.T) (*sqlite.TokenStore, *sqlite.Connection) {
+	conn, err := sqlite.NewConnection(":memory:")
 	assert.NoError(t, err)
 
-	return NewTokenStore(conn)
+	return sqlite.NewTokenStore(conn), conn
 }
 
 func TestTokenStore_First(t *testing.T) {
 	t.Run("given no rows", func(t *testing.T) {
-		store := newStore(t)
+		store, conn := newTestTokenStore(t)
+		defer conn.Close()
 
 		_, err := store.First()
 
-		assert.ErrorIs(t, err, storage.RecordNotFound)
+		assert.ErrorIs(t, err, storage.ErrorRecordNotFound)
 	})
 
 	t.Run("given one row", func(t *testing.T) {
-		store := newStore(t)
+		store, conn := newTestTokenStore(t)
+		defer conn.Close()
 
 		err := store.Add("token")
 		assert.NoError(t, err)
@@ -35,7 +39,8 @@ func TestTokenStore_First(t *testing.T) {
 	})
 
 	t.Run("given two rows then return first", func(t *testing.T) {
-		store := newStore(t)
+		store, conn := newTestTokenStore(t)
+		defer conn.Close()
 
 		err := store.Add("a")
 		assert.NoError(t, err)
@@ -51,7 +56,8 @@ func TestTokenStore_First(t *testing.T) {
 
 func TestTokenStore_Has(t *testing.T) {
 	t.Run("given no rows", func(t *testing.T) {
-		store := newStore(t)
+		store, conn := newTestTokenStore(t)
+		defer conn.Close()
 
 		hasToken, err := store.Has("token")
 
@@ -60,7 +66,8 @@ func TestTokenStore_Has(t *testing.T) {
 	})
 
 	t.Run("given one row", func(t *testing.T) {
-		store := newStore(t)
+		store, conn := newTestTokenStore(t)
+		defer conn.Close()
 
 		err := store.Add("token")
 		assert.NoError(t, err)
@@ -72,7 +79,8 @@ func TestTokenStore_Has(t *testing.T) {
 	})
 
 	t.Run("given one row with miss matching token", func(t *testing.T) {
-		store := newStore(t)
+		store, conn := newTestTokenStore(t)
+		defer conn.Close()
 
 		err := store.Add("token")
 		assert.NoError(t, err)


### PR DESCRIPTION
I have added tests for `PasswordStore` and `FileStore`.

There is an issue regarding the datatypes in `File` structure. Currently, all attributes are non-nullable. But there arises a case when `FileStore.ClearGroup()` method is used when `group_id` becomes `NULL` (The test for this scenario has been commented right now [here](https://github.com/irfanbacker/actual-sync/blob/9f55c850b5abf58875e41629e70c7167a4bfe8a2/internal/storage/sqlite/file_store_test.go#L163)). When this happens, All functions which scans data from the database will return errors since we'll be trying to assign nil to a string type. One way to solve this is to use `sql.Null<TypeName>` types.

What do you suggest we do here @nathanjisaac ?