### PR TITLE
feat: Setup CLI flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ node_modules
 
 # Actual
 data/
+*.yaml

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
+# <center> Actual-sync </center>
+
+___
 [![Go](https://github.com/nathanjisaac/actual-sync/actions/workflows/go.yml/badge.svg)](https://github.com/nathanjisaac/actual-sync/actions/workflows/go.yml)
 
 ## ⚠️⚠️ Work In Progress ⚠️⚠️
 
-The goal for this project is to migrate the [actualbudget/actual-server](https://github.com/actualbudget/actual-server) 
+The goal for this project is to migrate the [actualbudget/actual-server](https://github.com/actualbudget/actual-server)
 source code over to use [Go](https://go.dev/).
 
 ## Roadmap
@@ -11,9 +14,9 @@ Current roadmap is documented on the [roadmap discussion](https://github.com/nat
 
 ## Architecture
 
-The architecture is still somewhat of a WIP. But the high level gist looks like this. 
+The architecture is still somewhat of a WIP. But the high level gist looks like this.
 
-```
+```text
 main.go - Root Entrypoint
 cmd/ - CLI Entrypoint
 internal/
@@ -24,9 +27,51 @@ internal/
 
 ## CLI Usage
 
-> Planning to make this a standardized binary once the CLI api is stable.
+### actual-sync serve
 
-### Run Server
+This command will start the actual-sync server
+
+#### Synopsis
+
+This command will start the actual-sync server with the
+specified configurations along with this command.
+
+```shell
+actual-sync serve [flags]
+```
+
+#### Options
+
+```text
+  -d, --data-path string   Sets data directory path (default "data")
+  -l, --headless           Runs actual-sync without the web app
+  -h, --help               help for serve
+  -p, --port int           Runs actual-sync at specified port (default 5006)
+      --production         Runs actual-sync in production mode
+```
+
+#### Global options
+
+```text
+      --config string   config file (default is $HOME/.actual-sync.yaml)
+```
+
+### Development
+
+#### Dependencies
+
+- Node.js
+- go
+
+#### Steps to run
+
+1. Install node_modules (actual-web)
+
+```shell
+$ npm install
+```
+
+2. Run go program
 
 ```shell
 $ go run main.go serve

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 
 	"github.com/spf13/viper"
 )
@@ -13,13 +14,10 @@ var cfgFile string
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "actual-sync",
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "A sync server for actual budget",
+	Long: `actual-sync is a CLI application to run the sync server as
+well as the web instance of Actual, a local-first personal 
+finance tool.`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },
@@ -39,10 +37,6 @@ func init() {
 	// will be global for your application.
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.actual-sync.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/internal/server.go
+++ b/internal/server.go
@@ -1,0 +1,45 @@
+package internal
+
+import (
+	"embed"
+	"fmt"
+	"net/http"
+	"path/filepath"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"github.com/nathanjisaac/actual-server-go/internal/core"
+	"github.com/nathanjisaac/actual-server-go/internal/routes"
+	"github.com/nathanjisaac/actual-server-go/internal/storage/sqlite"
+)
+
+func StartServer(config core.Config, BuildDirectory embed.FS, headless bool) {
+	e := echo.New()
+	e.HideBanner = true
+
+	if !headless {
+		e.Use(middleware.StaticWithConfig(middleware.StaticConfig{
+			Root:       "node_modules/@actual-app/web/build",
+			HTML5:      true,
+			Filesystem: http.FS(BuildDirectory),
+		}))
+	}
+
+	conn, err := sqlite.NewAccountConnection(filepath.Join(config.ServerFiles, "account.sqlite"))
+	if err != nil {
+		e.Logger.Fatal(err)
+	}
+
+	handler := routes.RouteHandler{
+		Config:        config,
+		FileStore:     sqlite.NewFileStore(conn),
+		TokenStore:    sqlite.NewTokenStore(conn),
+		PasswordStore: sqlite.NewPasswordStore(conn),
+	}
+	e.GET("/mode", handler.GetMode)
+
+	account := e.Group("/account")
+	account.GET("/needs-bootstrap", handler.NeedsBootstrap)
+
+	e.Logger.Fatal(e.Start(fmt.Sprintf("%v:%v", config.Hostname, config.Port)))
+}


### PR DESCRIPTION
I have modified and added some basic flags for the CLI. The echo server component has been refactored and setup into another file inside `internal` as they are unrelated to the `cmd` module.