### PR TITLE
Implement sync routes

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nathanjisaac/actual-server-go/internal"
 	"github.com/nathanjisaac/actual-server-go/internal/core"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -37,13 +38,15 @@ specified configurations along with this command.`,
 		serverFiles := filepath.Join(dataPath, "server-files")
 		userFiles := filepath.Join(dataPath, "user-files")
 
-		err := os.MkdirAll(serverFiles, os.ModePerm)
+		fs := afero.NewOsFs()
+
+		err := fs.MkdirAll(serverFiles, os.ModePerm)
 
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		err = os.MkdirAll(userFiles, os.ModePerm)
+		err = fs.MkdirAll(userFiles, os.ModePerm)
 
 		if err != nil {
 			log.Fatal(err)
@@ -60,6 +63,7 @@ specified configurations along with this command.`,
 			Hostname:    "0.0.0.0",
 			ServerFiles: serverFiles,
 			UserFiles:   userFiles,
+			FileSystem:  fs,
 		}
 
 		internal.StartServer(config, BuildDirectory, headless)

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0
-	github.com/spf13/afero v1.8.2 // indirect
+	github.com/spf13/afero v1.8.2
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -1,5 +1,7 @@
 package core
 
+import "github.com/spf13/afero"
+
 type Mode int64
 
 const (
@@ -13,6 +15,7 @@ type Config struct {
 	Hostname    string
 	ServerFiles string
 	UserFiles   string
+	FileSystem  afero.Fs
 }
 
 func (it Config) ModeString() string {

--- a/internal/core/file_store.go
+++ b/internal/core/file_store.go
@@ -23,9 +23,11 @@ type NewFile struct {
 }
 
 type FileStore interface {
-	ForId(id FileId, deleted bool) (*File, error)
+	Count() (int, error)
+	ForId(id FileId) (*File, error)
+	ForIdAndDelete(id FileId, deleted bool) (*File, error)
 	All() ([]*File, error)
-	Update(file *File) error
+	Update(fileId string, syncVersion int16, encryptMeta string, name string) error
 	Add(file *NewFile) error
 	ClearGroup(id FileId) error
 	Delete(id FileId) error

--- a/internal/routes/handler.go
+++ b/internal/routes/handler.go
@@ -15,3 +15,8 @@ type ErrorResponse struct {
 	Status string `json:"status"`
 	Reason string `json:"reason"`
 }
+
+type SuccessResponse struct {
+	Status string      `json:"status"`
+	Data   interface{} `json:"data"`
+}

--- a/internal/routes/sync.go
+++ b/internal/routes/sync.go
@@ -1,0 +1,489 @@
+package routes
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strconv"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/nathanjisaac/actual-server-go/internal/core"
+	"github.com/nathanjisaac/actual-server-go/internal/storage"
+)
+
+type UserCreateKeyRequestBody struct {
+	FileId      string `json:"fileId"`
+	KeyId       string `json:"keyId"`
+	KeySalt     string `json:"keySalt"`
+	TestContent string `json:"testContent"`
+	Token       string `json:"token"`
+}
+
+func (it *RouteHandler) UserCreateKey(c echo.Context) error {
+	req := new(UserCreateKeyRequestBody)
+	if err := c.Bind(req); err != nil {
+		c.Echo().Logger.Error(err)
+		return err
+	}
+
+	val := it.authenticateUser(c, req.Token)
+	if !val {
+		r := &ErrorResponse{
+			Status: "error",
+			Reason: "auth-error",
+		}
+		return c.JSON(http.StatusUnauthorized, r)
+	}
+
+	err := it.FileStore.UpdateEncryption(req.FileId, req.KeySalt, req.KeyId, req.TestContent)
+	if err != nil {
+		c.Echo().Logger.Error(err)
+		return err
+	}
+
+	r := &SuccessResponse{Status: "ok"}
+	return c.JSON(http.StatusOK, r)
+}
+
+type UserGetKeyRequestBody struct {
+	FileId string `json:"fileId"`
+	Token  string `json:"token"`
+}
+
+type UserGetKeyResponse struct {
+	SuccessResponse
+	Data UserGetKeyResponseData `json:"data"`
+}
+
+type UserGetKeyResponseData struct {
+	EncryptKeyId string `json:"id"`
+	EncryptSalt  string `json:"salt"`
+	EncryptTest  string `json:"test"`
+}
+
+func (it *RouteHandler) UserGetKey(c echo.Context) error {
+	req := new(UserGetKeyRequestBody)
+	if err := c.Bind(req); err != nil {
+		c.Echo().Logger.Error(err)
+		return err
+	}
+
+	val := it.authenticateUser(c, req.Token)
+	if !val {
+		r := &ErrorResponse{
+			Status: "error",
+			Reason: "auth-error",
+		}
+		return c.JSON(http.StatusUnauthorized, r)
+	}
+
+	file, err := it.FileStore.ForId(req.FileId)
+	if err != nil {
+		if err == storage.ErrorRecordNotFound {
+			return c.String(http.StatusBadRequest, "file-not-found")
+		}
+		c.Echo().Logger.Error(err)
+		return err
+	}
+
+	r := &UserGetKeyResponse{
+		SuccessResponse: SuccessResponse{Status: "ok"},
+		Data: UserGetKeyResponseData{
+			EncryptKeyId: file.EncryptKeyId,
+			EncryptSalt:  file.EncryptSalt,
+			EncryptTest:  file.EncryptTest,
+		},
+	}
+	return c.JSON(http.StatusOK, r)
+}
+
+func (it *RouteHandler) ResetUserFile(c echo.Context) error {
+	req := new(UserGetKeyRequestBody)
+	if err := c.Bind(req); err != nil {
+		c.Echo().Logger.Error(err)
+		return err
+	}
+	val := it.authenticateUser(c, req.Token)
+	if !val {
+		r := &ErrorResponse{
+			Status: "error",
+			Reason: "auth-error",
+		}
+		return c.JSON(http.StatusUnauthorized, r)
+	}
+
+	err := it.FileStore.ClearGroup(req.FileId)
+	if err != nil {
+		if err == storage.ErrorNoRecordUpdated {
+			return c.String(http.StatusBadRequest, "User or file not found")
+		}
+		c.Echo().Logger.Error(err)
+		return err
+	}
+
+	r := &SuccessResponse{Status: "ok"}
+	return c.JSON(http.StatusOK, r)
+}
+
+type UpdateUserFileNameRequestBody struct {
+	FileId string `json:"fileId"`
+	Name   string `json:"name"`
+	Token  string `json:"token"`
+}
+
+func (it *RouteHandler) UpdateUserFileName(c echo.Context) error {
+	req := new(UpdateUserFileNameRequestBody)
+	if err := c.Bind(req); err != nil {
+		c.Echo().Logger.Error(err)
+		return err
+	}
+	val := it.authenticateUser(c, req.Token)
+	if !val {
+		r := &ErrorResponse{
+			Status: "error",
+			Reason: "auth-error",
+		}
+		return c.JSON(http.StatusUnauthorized, r)
+	}
+
+	err := it.FileStore.UpdateName(req.FileId, req.Name)
+	if err != nil {
+		if err == storage.ErrorNoRecordUpdated {
+			return c.String(http.StatusBadRequest, "User or file not found")
+		}
+		c.Echo().Logger.Error(err)
+		return err
+	}
+
+	r := &SuccessResponse{Status: "ok"}
+	return c.JSON(http.StatusOK, r)
+}
+
+type encryptMetaType struct {
+	KeyId string `json:"keyId"`
+}
+
+type UserFileInfoWithMetaResponse struct {
+	SuccessResponse
+	Data FileInfoWithMetaResponseData `json:"data"`
+}
+
+type FileInfoWithMetaResponseData struct {
+	Name        string          `json:"name"`
+	FileId      string          `json:"fileId"`
+	GroupId     string          `json:"groupId"`
+	EncryptMeta encryptMetaType `json:"encryptMeta"`
+	Deleted     bool            `json:"deleted"`
+}
+
+type UserFileInfoResponse struct {
+	SuccessResponse
+	Data FileInfoResponseData `json:"data"`
+}
+
+type FileInfoResponseData struct {
+	Name    string `json:"name"`
+	FileId  string `json:"fileId"`
+	GroupId string `json:"groupId"`
+	Deleted bool   `json:"deleted"`
+}
+
+func (it *RouteHandler) UserFileInfo(c echo.Context) error {
+	req := new(UserGetKeyRequestBody)
+	req.FileId = c.Request().Header.Get("x-actual-file-id")
+	if err := c.Bind(req); err != nil {
+		c.Echo().Logger.Error(err)
+		return err
+	}
+	val := it.authenticateUser(c, req.Token)
+	if !val {
+		r := &ErrorResponse{
+			Status: "error",
+			Reason: "auth-error",
+		}
+		return c.JSON(http.StatusUnauthorized, r)
+	}
+
+	file, err := it.FileStore.ForIdAndDelete(req.FileId, false)
+	if err != nil {
+		if err == storage.ErrorRecordNotFound {
+			return c.JSON(http.StatusBadRequest, ErrorResponse{Status: "error", Reason: "User or file not found"})
+		}
+		c.Echo().Logger.Error(err)
+		return err
+	}
+
+	if file.EncryptMeta != "" {
+		var meta encryptMetaType
+		err = json.Unmarshal([]byte(file.EncryptMeta), &meta)
+		if err != nil {
+			c.Echo().Logger.Error(err)
+			return err
+		}
+		r := UserFileInfoWithMetaResponse{
+			SuccessResponse: SuccessResponse{Status: "ok"},
+			Data:            FileInfoWithMetaResponseData{Name: file.Name, FileId: file.FileId, GroupId: file.GroupId, EncryptMeta: meta, Deleted: file.Deleted},
+		}
+		return c.JSON(http.StatusOK, r)
+	}
+
+	r := UserFileInfoResponse{
+		SuccessResponse: SuccessResponse{Status: "ok"},
+		Data:            FileInfoResponseData{Name: file.Name, FileId: file.FileId, GroupId: file.GroupId, Deleted: file.Deleted},
+	}
+	return c.JSON(http.StatusOK, r)
+}
+
+type TokenRequestBody struct {
+	Token string `json:"token"`
+}
+
+type ListFilesResponse struct {
+	SuccessResponse
+	Data []FileResponseData `json:"data"`
+}
+
+type FileResponseData struct {
+	Name         string `json:"name"`
+	FileId       string `json:"fileId"`
+	GroupId      string `json:"groupId"`
+	EncryptKeyId string `json:"encryptKeyIid"`
+	Deleted      bool   `json:"deleted"`
+}
+
+func (it *RouteHandler) ListUserFiles(c echo.Context) error {
+	req := new(TokenRequestBody)
+	if err := c.Bind(req); err != nil {
+		c.Echo().Logger.Error(err)
+		return err
+	}
+	val := it.authenticateUser(c, req.Token)
+	if !val {
+		r := &ErrorResponse{
+			Status: "error",
+			Reason: "auth-error",
+		}
+		return c.JSON(http.StatusUnauthorized, r)
+	}
+
+	files, err := it.FileStore.All()
+	if err != nil {
+		c.Echo().Logger.Error(err)
+		return err
+	}
+	filesRes := make([]FileResponseData, 0)
+	for _, file := range files {
+		filesRes = append(filesRes, FileResponseData{Name: file.Name, FileId: file.FileId, GroupId: file.GroupId, EncryptKeyId: file.EncryptKeyId, Deleted: file.Deleted})
+	}
+
+	r := &ListFilesResponse{
+		SuccessResponse: SuccessResponse{Status: "ok"},
+		Data:            filesRes,
+	}
+	return c.JSON(http.StatusOK, r)
+}
+
+type UploadUserFileResponse struct {
+	SuccessResponse
+	GroupId string `json:"groupId"`
+}
+
+func (it *RouteHandler) UploadUserFile(c echo.Context) error {
+	val := it.authenticateUser(c, "")
+	if !val {
+		r := &ErrorResponse{
+			Status: "error",
+			Reason: "auth-error",
+		}
+		return c.JSON(http.StatusUnauthorized, r)
+	}
+
+	name, err := url.PathUnescape(c.Request().Header.Get("x-actual-name"))
+	if err != nil {
+		c.Echo().Logger.Error(err)
+		return err
+	}
+	fileId := c.Request().Header.Get("x-actual-file-id")
+	groupId := c.Request().Header.Get("x-actual-group-id")
+	encryptMeta := c.Request().Header.Get("x-actual-encrypt-meta")
+	syncFormatVersion, err := strconv.ParseInt(c.Request().Header.Get("x-actual-format"), 10, 16)
+	if err != nil {
+		c.Echo().Logger.Error(err)
+		return err
+	}
+	keyId := ""
+	if encryptMeta != "" {
+		var jsonData encryptMetaType
+		err := json.Unmarshal([]byte(encryptMeta), &jsonData)
+		if err != nil {
+			c.Echo().Logger.Error(err)
+			return err
+		}
+		keyId = jsonData.KeyId
+	}
+
+	file, err := it.FileStore.ForId(fileId)
+	fileExists := false
+	if err != nil && err != storage.ErrorRecordNotFound {
+		c.Echo().Logger.Error(err)
+		return err
+	}
+	if err != storage.ErrorRecordNotFound {
+		fileExists = true
+		// The uploading file is part of an old group, so reject
+		// it. All of its internal sync state is invalid because its
+		// old. The sync state has been reset, so user needs to
+		// either reset again or download from the current group.
+		if groupId != file.GroupId {
+			return c.String(http.StatusBadRequest, "file-has-reset")
+		}
+
+		// The key that the file is encrypted with is different than
+		// the current registered key. All data must always be
+		// encrypted with the registered key for consistency. Key
+		// changes always necessitate a sync reset, which means this
+		// upload is trying to overwrite another reset. That might
+		// be be fine, but since we definitely cannot accept a file
+		// encrypted with the wrong key, we bail and suggest the
+		// user download the latest file.
+		if keyId != file.EncryptKeyId {
+			return c.String(http.StatusBadRequest, "file-has-new-key")
+		}
+	}
+
+	out, err := it.Config.FileSystem.Create(filepath.Join(it.Config.UserFiles, fmt.Sprintf("%s.blob", fileId)))
+	if err != nil {
+		c.Echo().Logger.Error(err)
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, c.Request().Body)
+	if err != nil {
+		c.Echo().Logger.Error(err)
+		return err
+	}
+
+	if !fileExists {
+		// Its new
+		uuid, err := uuid.NewRandom()
+		if err != nil {
+			c.Echo().Logger.Error(err)
+			return err
+		}
+		groupId = uuid.String()
+
+		err = it.FileStore.Add(&core.NewFile{FileId: fileId, GroupId: groupId, SyncVersion: int16(syncFormatVersion), EncryptMeta: encryptMeta, Name: name})
+		if err != nil {
+			c.Echo().Logger.Error(err)
+			return err
+		}
+
+		r := UploadUserFileResponse{
+			SuccessResponse: SuccessResponse{Status: "ok"},
+			GroupId:         groupId,
+		}
+		return c.JSON(http.StatusOK, r)
+	} else {
+		if groupId == "" {
+			// Sync state was reset. Create new group
+			uuid, err := uuid.NewRandom()
+			if err != nil {
+				c.Echo().Logger.Error(err)
+				return err
+			}
+			groupId = uuid.String()
+
+			err = it.FileStore.UpdateGroup(fileId, groupId)
+			if err != nil {
+				c.Echo().Logger.Error(err)
+				return err
+			}
+		}
+
+		// Regardless, update properties
+		err = it.FileStore.Update(fileId, int16(syncFormatVersion), encryptMeta, name)
+		if err != nil {
+			c.Echo().Logger.Error(err)
+			return err
+		}
+
+		r := UploadUserFileResponse{
+			SuccessResponse: SuccessResponse{Status: "ok"},
+			GroupId:         groupId,
+		}
+		return c.JSON(http.StatusOK, r)
+	}
+}
+
+func (it *RouteHandler) DownloadUserFile(c echo.Context) error {
+	val := it.authenticateUser(c, "")
+	if !val {
+		r := &ErrorResponse{
+			Status: "error",
+			Reason: "auth-error",
+		}
+		return c.JSON(http.StatusUnauthorized, r)
+	}
+
+	fileId := c.Request().Header.Get("x-actual-file-id")
+
+	_, err := it.FileStore.ForIdAndDelete(fileId, false)
+	if err != nil {
+		if err == storage.ErrorRecordNotFound {
+			return c.String(http.StatusBadRequest, "User or file not found")
+		}
+		c.Echo().Logger.Error(err)
+		return err
+	}
+
+	fs := it.Config.FileSystem
+	file, err := fs.Open(filepath.Join(it.Config.UserFiles, fmt.Sprintf("%s.blob", fileId)))
+	if err != nil {
+		return c.String(http.StatusInternalServerError, "Error reading files")
+	}
+	defer file.Close()
+	finfo, err := file.Stat()
+	if err != nil {
+		return c.String(http.StatusInternalServerError, "Error reading files")
+	}
+	fileBlob := make([]byte, finfo.Size())
+	_, err = file.Read(fileBlob)
+	if err != nil {
+		return c.String(http.StatusInternalServerError, "Error reading files")
+	}
+
+	c.Response().Header().Set(echo.HeaderContentDisposition, fmt.Sprintf("attachment; filename=%q", fileId))
+	return c.Blob(http.StatusOK, echo.MIMEOctetStream, fileBlob)
+}
+
+func (it *RouteHandler) DeleteUserFile(c echo.Context) error {
+	req := new(UserGetKeyRequestBody)
+	if err := c.Bind(req); err != nil {
+		c.Echo().Logger.Error(err)
+		return err
+	}
+	val := it.authenticateUser(c, req.Token)
+	if !val {
+		r := &ErrorResponse{
+			Status: "error",
+			Reason: "auth-error",
+		}
+		return c.JSON(http.StatusUnauthorized, r)
+	}
+
+	err := it.FileStore.Delete(req.FileId)
+	if err != nil {
+		if err == storage.ErrorNoRecordUpdated {
+			return c.String(http.StatusBadRequest, "User or file not found")
+		}
+		c.Echo().Logger.Error(err)
+		return err
+	}
+
+	r := &SuccessResponse{Status: "ok"}
+	return c.JSON(http.StatusOK, r)
+}

--- a/internal/routes/sync_test.go
+++ b/internal/routes/sync_test.go
@@ -1,0 +1,867 @@
+package routes_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/nathanjisaac/actual-server-go/internal/core"
+	"github.com/nathanjisaac/actual-server-go/internal/routes"
+	"github.com/nathanjisaac/actual-server-go/internal/storage/sqlite"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupSyncTestHandler(body string, tstore core.TokenStore, fstore core.FileStore) (*routes.RouteHandler, echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	config := core.Config{
+		Mode: core.Development,
+	}
+	h := &routes.RouteHandler{
+		Config:        config,
+		FileStore:     nil,
+		PasswordStore: nil,
+		TokenStore:    nil,
+	}
+	if fstore != nil && tstore == nil {
+		h = &routes.RouteHandler{
+			Config:        config,
+			FileStore:     fstore,
+			PasswordStore: nil,
+			TokenStore:    nil,
+		}
+	} else if fstore == nil && tstore != nil {
+		h = &routes.RouteHandler{
+			Config:        config,
+			FileStore:     nil,
+			PasswordStore: nil,
+			TokenStore:    tstore,
+		}
+	} else if fstore != nil && tstore != nil {
+		h = &routes.RouteHandler{
+			Config:        config,
+			FileStore:     fstore,
+			PasswordStore: nil,
+			TokenStore:    tstore,
+		}
+	}
+	return h, c, rec
+}
+
+func setupSyncTestFileHandler(body []byte, tstore core.TokenStore, fstore core.FileStore, fileId string) (*routes.RouteHandler, echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentDisposition, fmt.Sprintf("attachment;filename=%s", fileId))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	fs := afero.NewMemMapFs()
+	config := core.Config{
+		Mode:       core.Development,
+		FileSystem: fs,
+		UserFiles:  "",
+	}
+	h := &routes.RouteHandler{
+		Config:        config,
+		FileStore:     nil,
+		PasswordStore: nil,
+		TokenStore:    nil,
+	}
+	if fstore != nil && tstore == nil {
+		h = &routes.RouteHandler{
+			Config:        config,
+			FileStore:     fstore,
+			PasswordStore: nil,
+			TokenStore:    nil,
+		}
+	} else if fstore == nil && tstore != nil {
+		h = &routes.RouteHandler{
+			Config:        config,
+			FileStore:     nil,
+			PasswordStore: nil,
+			TokenStore:    tstore,
+		}
+	} else if fstore != nil && tstore != nil {
+		h = &routes.RouteHandler{
+			Config:        config,
+			FileStore:     fstore,
+			PasswordStore: nil,
+			TokenStore:    tstore,
+		}
+	}
+	return h, c, rec
+}
+
+func TestUserCreateKey(t *testing.T) {
+	t.Run("given no token in returns error", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"fileId":"1","keyId":"2","keySalt":"3","testContent":"4"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+
+		var res routes.ErrorResponse
+		err = h.UserCreateKey(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "error", res.Status)
+		assert.Equal(t, "auth-error", res.Reason)
+	})
+
+	t.Run("given token and no valid file returns error", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, _ := setupSyncTestHandler(`{"token":"token123"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+
+		err = h.UserCreateKey(c)
+		assert.Error(t, err)
+		assert.Equal(t, "no record updated", err.Error())
+	})
+
+	t.Run("given token and valid file returns success", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"token":"token123","fileId":"f1","keyId":"2","keySalt":"3","testContent":"4"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+		err = fstore.Add(&core.NewFile{FileId: "f1", GroupId: "g1", SyncVersion: 2, EncryptMeta: "abc", Name: "budget"})
+		assert.NoError(t, err)
+
+		var res routes.SuccessResponse
+		err = h.UserCreateKey(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "ok", res.Status)
+
+		file, err := fstore.ForId("f1")
+		assert.NoError(t, err)
+		assert.Equal(t, "2", file.EncryptKeyId)
+		assert.Equal(t, "3", file.EncryptSalt)
+		assert.Equal(t, "4", file.EncryptTest)
+	})
+}
+
+func TestUserGetKey(t *testing.T) {
+	t.Run("given no token in returns error", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"fileId":"1"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+
+		var res routes.ErrorResponse
+		err = h.UserGetKey(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "error", res.Status)
+		assert.Equal(t, "auth-error", res.Reason)
+	})
+
+	t.Run("given token and no valid file returns error", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"token":"token123"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+
+		err = h.UserGetKey(c)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "file-not-found", rec.Body.String())
+	})
+
+	t.Run("given token and valid file returns success", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"token":"token123","fileId":"f1","keyId":"2","keySalt":"3","testContent":"4"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+		err = fstore.Add(&core.NewFile{FileId: "f1", GroupId: "g1", SyncVersion: 2, EncryptMeta: "abc", Name: "budget"})
+		assert.NoError(t, err)
+		err = fstore.UpdateEncryption("f1", "salt", "keyid", "test")
+		assert.NoError(t, err)
+
+		var res routes.UserGetKeyResponse
+		err = h.UserGetKey(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "ok", res.Status)
+		assert.Equal(t, "keyid", res.Data.EncryptKeyId)
+		assert.Equal(t, "salt", res.Data.EncryptSalt)
+		assert.Equal(t, "test", res.Data.EncryptTest)
+	})
+}
+
+func TestResetUserFile(t *testing.T) {
+	t.Run("given no token in returns error", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"fileId":"1"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+
+		var res routes.ErrorResponse
+		err = h.ResetUserFile(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "error", res.Status)
+		assert.Equal(t, "auth-error", res.Reason)
+	})
+
+	t.Run("given token and no valid file returns error", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"token":"token123"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+
+		err = h.ResetUserFile(c)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "User or file not found", rec.Body.String())
+	})
+
+	t.Run("given token and valid file returns success", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"token":"token123","fileId":"f1"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+		err = fstore.Add(&core.NewFile{FileId: "f1", GroupId: "g1", SyncVersion: 2, EncryptMeta: "abc", Name: "budget"})
+		assert.NoError(t, err)
+		err = fstore.UpdateEncryption("f1", "salt", "keyid", "test")
+		assert.NoError(t, err)
+
+		var res routes.SuccessResponse
+		err = h.ResetUserFile(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "ok", res.Status)
+
+		file, err := fstore.ForId("f1")
+		assert.NoError(t, err)
+		assert.Equal(t, "", file.GroupId)
+	})
+}
+
+func TestUpdateUserFileName(t *testing.T) {
+	t.Run("given no token in returns error", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"fileId":"1","name":"budgetnew"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+
+		var res routes.ErrorResponse
+		err = h.UpdateUserFileName(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "error", res.Status)
+		assert.Equal(t, "auth-error", res.Reason)
+	})
+
+	t.Run("given token and no valid file returns error", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"token":"token123"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+
+		err = h.UpdateUserFileName(c)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "User or file not found", rec.Body.String())
+	})
+
+	t.Run("given token and valid file returns success", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"token":"token123","fileId":"f1","name":"budgetnew"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+		err = fstore.Add(&core.NewFile{FileId: "f1", GroupId: "g1", SyncVersion: 2, EncryptMeta: "abc", Name: "budget"})
+		assert.NoError(t, err)
+		err = fstore.UpdateEncryption("f1", "salt", "keyid", "test")
+		assert.NoError(t, err)
+
+		var res routes.SuccessResponse
+		err = h.UpdateUserFileName(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "ok", res.Status)
+
+		file, err := fstore.ForId("f1")
+		assert.NoError(t, err)
+		assert.Equal(t, "budgetnew", file.Name)
+	})
+}
+
+func TestUserFileInfo(t *testing.T) {
+	t.Run("given no token in returns error", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"fileId":"1"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+
+		var res routes.ErrorResponse
+		err = h.UserFileInfo(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "error", res.Status)
+		assert.Equal(t, "auth-error", res.Reason)
+	})
+
+	t.Run("given token and no files returns error", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"token":"token123"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+		c.Request().Header.Set("x-actual-file-id", "f1")
+
+		var res routes.ErrorResponse
+		err = h.UserFileInfo(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "error", res.Status)
+		assert.Equal(t, "User or file not found", res.Reason)
+	})
+
+	t.Run("given token and file exists returns info without encrypt meta", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"token":"token123"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+		c.Request().Header.Set("x-actual-file-id", "f1")
+
+		err = fstore.Add(&core.NewFile{FileId: "f1", GroupId: "g1", SyncVersion: 2, EncryptMeta: "", Name: "budget"})
+		assert.NoError(t, err)
+		err = fstore.UpdateEncryption("f1", "salt", "keyid", "test")
+		assert.NoError(t, err)
+
+		var res routes.UserFileInfoResponse
+		err = h.UserFileInfo(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "ok", res.Status)
+
+		assert.Equal(t, "f1", res.Data.FileId)
+		assert.Equal(t, "g1", res.Data.GroupId)
+		assert.Equal(t, "budget", res.Data.Name)
+		assert.Equal(t, false, res.Data.Deleted)
+	})
+
+	t.Run("given token and file exists returns info with encrypt meta", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"token":"token123"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+		c.Request().Header.Set("x-actual-file-id", "f1")
+
+		err = fstore.Add(&core.NewFile{FileId: "f1", GroupId: "g1", SyncVersion: 2, EncryptMeta: `{"keyId":"keyidMeta"}`, Name: "budget"})
+		assert.NoError(t, err)
+		err = fstore.UpdateEncryption("f1", "salt", "keyid", "test")
+		assert.NoError(t, err)
+
+		var res routes.UserFileInfoWithMetaResponse
+		err = h.UserFileInfo(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "ok", res.Status)
+
+		assert.Equal(t, "f1", res.Data.FileId)
+		assert.Equal(t, "g1", res.Data.GroupId)
+		assert.Equal(t, "keyidMeta", res.Data.EncryptMeta.KeyId)
+		assert.Equal(t, "budget", res.Data.Name)
+		assert.Equal(t, false, res.Data.Deleted)
+	})
+}
+
+func TestListUserFiles(t *testing.T) {
+	t.Run("given no token in returns error", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"fileId":"1"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+
+		var res routes.ErrorResponse
+		err = h.ListUserFiles(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "error", res.Status)
+		assert.Equal(t, "auth-error", res.Reason)
+	})
+
+	t.Run("given token and no files returns empty array", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"token":"token123"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+
+		var res routes.ListFilesResponse
+		err = h.ListUserFiles(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "ok", res.Status)
+		assert.Equal(t, 0, len(res.Data))
+	})
+
+	t.Run("given token and two valid file returns array", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"token":"token123","fileId":"f1"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+
+		err = fstore.Add(&core.NewFile{FileId: "f1", GroupId: "g1", SyncVersion: 2, EncryptMeta: "abc", Name: "budget"})
+		assert.NoError(t, err)
+		err = fstore.UpdateEncryption("f1", "salt", "keyid", "test")
+		assert.NoError(t, err)
+
+		err = fstore.Add(&core.NewFile{FileId: "f2", GroupId: "g2", SyncVersion: 2, EncryptMeta: "abc2", Name: "budget2"})
+		assert.NoError(t, err)
+		err = fstore.UpdateEncryption("f2", "salt2", "keyid2", "test2")
+		assert.NoError(t, err)
+
+		var res routes.ListFilesResponse
+		err = h.ListUserFiles(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "ok", res.Status)
+		assert.Equal(t, 2, len(res.Data))
+
+		assert.Equal(t, "f1", res.Data[0].FileId)
+		assert.Equal(t, "g1", res.Data[0].GroupId)
+		assert.Equal(t, "keyid", res.Data[0].EncryptKeyId)
+		assert.Equal(t, "budget", res.Data[0].Name)
+		assert.Equal(t, false, res.Data[0].Deleted)
+
+		assert.Equal(t, "f2", res.Data[1].FileId)
+		assert.Equal(t, "g2", res.Data[1].GroupId)
+		assert.Equal(t, "keyid2", res.Data[1].EncryptKeyId)
+		assert.Equal(t, "budget2", res.Data[1].Name)
+		assert.Equal(t, false, res.Data[1].Deleted)
+	})
+}
+
+func TestUploadUserFIle(t *testing.T) {
+	t.Run("given no token in returns error", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestFileHandler([]byte{}, tstore, fstore, "")
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+
+		var res routes.ErrorResponse
+		err = h.UploadUserFile(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "error", res.Status)
+		assert.Equal(t, "auth-error", res.Reason)
+	})
+
+	t.Run("given logged in and no files then adds file and returns success", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestFileHandler([]byte("testing"), tstore, fstore, "f1")
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+		c.Request().Header.Set("x-actual-token", "token123")
+		c.Request().Header.Set("x-actual-name", "budget")
+		c.Request().Header.Set("x-actual-file-id", "f1")
+		c.Request().Header.Set("x-actual-group-id", "g1")
+		c.Request().Header.Set("x-actual-encrypt-meta", `{"keyId": "keyid"}`)
+		c.Request().Header.Set("x-actual-format", "2")
+
+		var res routes.UploadUserFileResponse
+		err = h.UploadUserFile(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "ok", res.Status)
+		_, err = uuid.Parse(res.GroupId)
+		assert.NoError(t, err)
+
+		count, err := fstore.Count()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, count)
+
+		fs := h.Config.FileSystem
+		result, err := afero.FileContainsBytes(fs, filepath.Join(h.Config.UserFiles, "f1.blob"), []byte("testing"))
+		assert.NoError(t, err)
+		assert.Equal(t, true, result)
+	})
+
+	t.Run("given logged in, old groupid and file exists then returns error", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestFileHandler([]byte("testing"), tstore, fstore, "f1")
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+		c.Request().Header.Set("x-actual-token", "token123")
+		c.Request().Header.Set("x-actual-name", "budget")
+		c.Request().Header.Set("x-actual-file-id", "f1")
+		c.Request().Header.Set("x-actual-group-id", "g2")
+		c.Request().Header.Set("x-actual-encrypt-meta", `{"keyId": "keyid"}`)
+		c.Request().Header.Set("x-actual-format", "2")
+		err = fstore.Add(&core.NewFile{FileId: "f1", GroupId: "g1", SyncVersion: 2, EncryptMeta: "abc", Name: "budget"})
+		assert.NoError(t, err)
+		err = fstore.UpdateEncryption("f1", "salt", "keyid", "test")
+		assert.NoError(t, err)
+
+		err = h.UploadUserFile(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "file-has-reset", rec.Body.String())
+	})
+
+	t.Run("given logged in, old encypt keyid and file exists then returns error", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestFileHandler([]byte("testing"), tstore, fstore, "f1")
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+		c.Request().Header.Set("x-actual-token", "token123")
+		c.Request().Header.Set("x-actual-name", "budget")
+		c.Request().Header.Set("x-actual-file-id", "f1")
+		c.Request().Header.Set("x-actual-group-id", "g1")
+		c.Request().Header.Set("x-actual-encrypt-meta", `{"keyId": "keyid"}`)
+		c.Request().Header.Set("x-actual-format", "2")
+		err = fstore.Add(&core.NewFile{FileId: "f1", GroupId: "g1", SyncVersion: 2, EncryptMeta: "abc", Name: "budget"})
+		assert.NoError(t, err)
+		err = fstore.UpdateEncryption("f1", "salt", "keyid2", "test")
+		assert.NoError(t, err)
+
+		err = h.UploadUserFile(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "file-has-new-key", rec.Body.String())
+	})
+
+	t.Run("given logged in and file exists then returns success", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestFileHandler([]byte("testing"), tstore, fstore, "f1")
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+		c.Request().Header.Set("x-actual-token", "token123")
+		c.Request().Header.Set("x-actual-name", "budgetnew")
+		c.Request().Header.Set("x-actual-file-id", "f1")
+		c.Request().Header.Set("x-actual-group-id", "g1")
+		c.Request().Header.Set("x-actual-encrypt-meta", `{"keyId": "keyid"}`)
+		c.Request().Header.Set("x-actual-format", "3")
+		err = fstore.Add(&core.NewFile{FileId: "f1", GroupId: "g1", SyncVersion: 2, EncryptMeta: "abc", Name: "budget"})
+		assert.NoError(t, err)
+		err = fstore.UpdateEncryption("f1", "salt", "keyid", "test")
+		assert.NoError(t, err)
+
+		var res routes.UploadUserFileResponse
+		err = h.UploadUserFile(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "ok", res.Status)
+		assert.Equal(t, "g1", res.GroupId)
+
+		file, err := fstore.ForId("f1")
+		assert.NoError(t, err)
+		assert.Equal(t, int16(3), file.SyncVersion)
+		assert.Equal(t, "budgetnew", file.Name)
+
+		fs := h.Config.FileSystem
+		result, err := afero.FileContainsBytes(fs, filepath.Join(h.Config.UserFiles, "f1.blob"), []byte("testing"))
+		assert.NoError(t, err)
+		assert.Equal(t, true, result)
+	})
+}
+
+func TestDownloadUserFIle(t *testing.T) {
+	t.Run("given no token in returns error", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestFileHandler([]byte{}, tstore, fstore, "")
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+
+		var res routes.ErrorResponse
+		err = h.DownloadUserFile(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "error", res.Status)
+		assert.Equal(t, "auth-error", res.Reason)
+	})
+
+	t.Run("given logged in and no files then returns error", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestFileHandler([]byte("testing"), tstore, fstore, "f1")
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+		c.Request().Header.Set("x-actual-token", "token123")
+		c.Request().Header.Set("x-actual-file-id", "f1")
+
+		err = h.DownloadUserFile(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "User or file not found", rec.Body.String())
+	})
+
+	t.Run("given logged in and file exists then returns success", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestFileHandler([]byte("testing"), tstore, fstore, "f1")
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+		c.Request().Header.Set("x-actual-token", "token123")
+		c.Request().Header.Set("x-actual-file-id", "f1")
+		err = fstore.Add(&core.NewFile{FileId: "f1", GroupId: "g1", SyncVersion: 2, EncryptMeta: "abc", Name: "budget"})
+		assert.NoError(t, err)
+		err = fstore.UpdateEncryption("f1", "salt", "keyid", "test")
+		assert.NoError(t, err)
+
+		out, err := h.Config.FileSystem.Create(filepath.Join(h.Config.UserFiles, "f1.blob"))
+		assert.NoError(t, err)
+		defer out.Close()
+		_, err = io.Copy(out, bytes.NewReader([]byte("testing")))
+		assert.NoError(t, err)
+
+		err = h.DownloadUserFile(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, []byte("testing"), rec.Body.Bytes())
+	})
+}
+
+func TestDeleteUserFile(t *testing.T) {
+	t.Run("given no token in returns error", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"fileId":"1"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+
+		var res routes.ErrorResponse
+		err = h.DeleteUserFile(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "error", res.Status)
+		assert.Equal(t, "auth-error", res.Reason)
+	})
+
+	t.Run("given token and no valid file returns error", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"token":"token123"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+
+		err = h.DeleteUserFile(c)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "User or file not found", rec.Body.String())
+	})
+
+	t.Run("given token and valid file returns success", func(t *testing.T) {
+		db, err := sqlite.NewAccountConnection(":memory:")
+		assert.NoError(t, err)
+		defer db.Close()
+		tstore := sqlite.NewTokenStore(db)
+		fstore := sqlite.NewFileStore(db)
+		h, c, rec := setupSyncTestHandler(`{"token":"token123","fileId":"f1"}`, tstore, fstore)
+
+		err = tstore.Add("token123")
+		assert.NoError(t, err)
+		err = fstore.Add(&core.NewFile{FileId: "f1", GroupId: "g1", SyncVersion: 2, EncryptMeta: "abc", Name: "budget"})
+		assert.NoError(t, err)
+		err = fstore.UpdateEncryption("f1", "salt", "keyid", "test")
+		assert.NoError(t, err)
+
+		var res routes.SuccessResponse
+		err = h.DeleteUserFile(c)
+		assert.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+		assert.Equal(t, "ok", res.Status)
+
+		file, err := fstore.ForId("f1")
+		assert.NoError(t, err)
+		assert.Equal(t, true, file.Deleted)
+	})
+}

--- a/internal/server.go
+++ b/internal/server.go
@@ -28,6 +28,9 @@ func StartServer(config core.Config, BuildDirectory embed.FS, headless bool) {
 
 	e.Use(middleware.CORS())
 	e.Use(setHeaders)
+	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
+		Format: "method=${method}, uri=${uri}, status=${status}\n",
+	}))
 
 	if !headless {
 		e.Use(middleware.StaticWithConfig(middleware.StaticConfig{
@@ -56,6 +59,17 @@ func StartServer(config core.Config, BuildDirectory embed.FS, headless bool) {
 	account.POST("/login", handler.Login)
 	account.POST("/change-password", handler.ChangePassword)
 	account.GET("/validate", handler.ValidateUser)
+
+	sync := e.Group("/sync")
+	sync.POST("/user-create-key", handler.UserCreateKey)
+	sync.POST("/user-get-key", handler.UserGetKey)
+	sync.POST("/reset-user-file", handler.ResetUserFile)
+	sync.POST("/update-user-filename", handler.UpdateUserFileName)
+	sync.GET("/get-user-file-info", handler.UserFileInfo)
+	sync.GET("/list-user-files", handler.ListUserFiles)
+	sync.POST("/upload-user-file", handler.UploadUserFile)
+	sync.GET("/download-user-file", handler.DownloadUserFile)
+	sync.POST("/delete-user-file", handler.DeleteUserFile)
 
 	e.Logger.Fatal(e.Start(fmt.Sprintf("%v:%v", config.Hostname, config.Port)))
 }

--- a/internal/storage/sqlite/file_store_test.go
+++ b/internal/storage/sqlite/file_store_test.go
@@ -16,12 +16,39 @@ func newTestFileStore(t *testing.T) (*sqlite.FileStore, *sqlite.Connection) {
 	return sqlite.NewFileStore(conn), conn
 }
 
+func TestFileStore_Count(t *testing.T) {
+	t.Run("given no rows", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		c, err := store.Count()
+
+		assert.NoError(t, err)
+		assert.Equal(t, 0, c)
+	})
+
+	t.Run("given two row", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		err := store.Add(&core.NewFile{FileId: "f1", GroupId: "g1", SyncVersion: 2, EncryptMeta: "meta", Name: "budget"})
+		assert.NoError(t, err)
+		err = store.Add(&core.NewFile{FileId: "f2", GroupId: "g2", SyncVersion: 2, EncryptMeta: "meta2", Name: "budget2"})
+		assert.NoError(t, err)
+
+		c, err := store.Count()
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, c)
+	})
+}
+
 func TestFileStore_ForId(t *testing.T) {
 	t.Run("given no rows", func(t *testing.T) {
 		store, conn := newTestFileStore(t)
 		defer conn.Close()
 
-		_, err := store.ForId("1", false)
+		_, err := store.ForId("1")
 
 		assert.ErrorIs(t, err, storage.ErrorRecordNotFound)
 	})
@@ -45,7 +72,43 @@ func TestFileStore_ForId(t *testing.T) {
 		err = store.UpdateEncryption("3", "salt3", "keyid3", "test3")
 		assert.NoError(t, err)
 
-		f, err := store.ForId("2", false)
+		f, err := store.ForId("2")
+
+		assert.NoError(t, err)
+		assert.Equal(t, &core.File{FileId: "2", GroupId: "g2", SyncVersion: 2, EncryptMeta: "B1F2G3", EncryptSalt: "salt2", EncryptKeyId: "keyid2", EncryptTest: "test2", Deleted: false, Name: "Budget2"}, f)
+	})
+}
+
+func TestFileStore_ForIdAndDelete(t *testing.T) {
+	t.Run("given no rows", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		_, err := store.ForIdAndDelete("1", false)
+
+		assert.ErrorIs(t, err, storage.ErrorRecordNotFound)
+	})
+
+	t.Run("given three rows returns second", func(t *testing.T) {
+		store, conn := newTestFileStore(t)
+		defer conn.Close()
+
+		err := store.Add(&core.NewFile{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", Name: "Budget"})
+		assert.NoError(t, err)
+		err = store.UpdateEncryption("1", "salt1", "keyid1", "test1")
+		assert.NoError(t, err)
+
+		err = store.Add(&core.NewFile{FileId: "2", GroupId: "g2", SyncVersion: 2, EncryptMeta: "B1F2G3", Name: "Budget2"})
+		assert.NoError(t, err)
+		err = store.UpdateEncryption("2", "salt2", "keyid2", "test2")
+		assert.NoError(t, err)
+
+		err = store.Add(&core.NewFile{FileId: "3", GroupId: "g3", SyncVersion: 3, EncryptMeta: "B4F7G9", Name: "Budget3"})
+		assert.NoError(t, err)
+		err = store.UpdateEncryption("3", "salt3", "keyid3", "test3")
+		assert.NoError(t, err)
+
+		f, err := store.ForIdAndDelete("2", false)
 
 		assert.NoError(t, err)
 		assert.Equal(t, &core.File{FileId: "2", GroupId: "g2", SyncVersion: 2, EncryptMeta: "B1F2G3", EncryptSalt: "salt2", EncryptKeyId: "keyid2", EncryptTest: "test2", Deleted: false, Name: "Budget2"}, f)
@@ -97,7 +160,7 @@ func TestFileStore_Update(t *testing.T) {
 		store, conn := newTestFileStore(t)
 		defer conn.Close()
 
-		err := store.Update(&core.File{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: false, Name: "Budget1"})
+		err := store.Update("1", 1, "A1B2C3", "Budget1")
 
 		assert.ErrorIs(t, err, storage.ErrorNoRecordUpdated)
 	})
@@ -111,10 +174,10 @@ func TestFileStore_Update(t *testing.T) {
 		err = store.UpdateEncryption("1", "salt1", "keyid1", "test1")
 		assert.NoError(t, err)
 
-		err = store.Update(&core.File{FileId: "1", GroupId: "g1", SyncVersion: 2, EncryptMeta: "X9Y6Z7", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: false, Name: "Budget1"})
+		err = store.Update("1", 2, "X9Y6Z7", "Budget1")
 		assert.NoError(t, err)
 
-		f, err := store.ForId("1", false)
+		f, err := store.ForId("1")
 
 		assert.NoError(t, err)
 		assert.Equal(t, &core.File{FileId: "1", GroupId: "g1", SyncVersion: 2, EncryptMeta: "X9Y6Z7", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: false, Name: "Budget1"}, f)
@@ -131,7 +194,7 @@ func TestFileStore_Add(t *testing.T) {
 		err = store.UpdateEncryption("1", "salt1", "keyid1", "test1")
 		assert.NoError(t, err)
 
-		f, err := store.ForId("1", false)
+		f, err := store.ForId("1")
 
 		assert.NoError(t, err)
 		assert.Equal(t, &core.File{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: false, Name: "Budget1"}, f)
@@ -160,7 +223,7 @@ func TestFileStore_ClearGroup(t *testing.T) {
 		err = store.ClearGroup("1")
 		assert.NoError(t, err)
 
-		f, err := store.ForId("1", false)
+		f, err := store.ForId("1")
 
 		assert.NoError(t, err)
 		assert.Equal(t, &core.File{FileId: "1", GroupId: "", SyncVersion: 1, EncryptMeta: "A1B2C3", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: false, Name: "Budget1"}, f)
@@ -189,7 +252,7 @@ func TestFileStore_Delete(t *testing.T) {
 		err = store.Delete("1")
 		assert.NoError(t, err)
 
-		f, err := store.ForId("1", true)
+		f, err := store.ForId("1")
 
 		assert.NoError(t, err)
 		assert.Equal(t, &core.File{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: true, Name: "Budget1"}, f)
@@ -218,7 +281,7 @@ func TestFileStore_UpdateName(t *testing.T) {
 		err = store.UpdateName("1", "My budget")
 		assert.NoError(t, err)
 
-		f, err := store.ForId("1", false)
+		f, err := store.ForId("1")
 
 		assert.NoError(t, err)
 		assert.Equal(t, &core.File{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: false, Name: "My budget"}, f)
@@ -247,7 +310,7 @@ func TestFileStore_UpdateGroup(t *testing.T) {
 		err = store.UpdateGroup("1", "gnew")
 		assert.NoError(t, err)
 
-		f, err := store.ForId("1", false)
+		f, err := store.ForId("1")
 
 		assert.NoError(t, err)
 		assert.Equal(t, &core.File{FileId: "1", GroupId: "gnew", SyncVersion: 1, EncryptMeta: "A1B2C3", EncryptSalt: "salt1", EncryptKeyId: "keyid1", EncryptTest: "test1", Deleted: false, Name: "Budget1"}, f)
@@ -276,7 +339,7 @@ func TestFileStore_UpdateEncryption(t *testing.T) {
 		err = store.UpdateEncryption("1", "saltNew", "keyidNew", "testNew")
 		assert.NoError(t, err)
 
-		f, err := store.ForId("1", false)
+		f, err := store.ForId("1")
 
 		assert.NoError(t, err)
 		assert.Equal(t, &core.File{FileId: "1", GroupId: "g1", SyncVersion: 1, EncryptMeta: "A1B2C3", EncryptSalt: "saltNew", EncryptKeyId: "keyidNew", EncryptTest: "testNew", Deleted: false, Name: "Budget1"}, f)


### PR DESCRIPTION
Implemented every sync routes except `/sync/sync`. I haven't implemented a basic memory `FileStore` for the tests. I used in-memory sqlite.